### PR TITLE
Mark desktop file as mobile-friendly for Phosh

### DIFF
--- a/data/io.github.v81d.Wattage.desktop.in
+++ b/data/io.github.v81d.Wattage.desktop.in
@@ -9,3 +9,5 @@ Categories=Utility;
 Keywords=GTK;Battery monitor;Battery health;Power statistics;Power usage;Power devices;
 StartupNotify=true
 DBusActivatable=true
+# Translators: Do NOT translate or transliterate this text (these are enum types)!
+X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
Wattage seems to work well on the Librem Phone (and mobile form factors in general, thanks for that!) and also to monitor battery health there. However, by default it's not shown on the start screen after installation unless you tap 'Show all apps' (as opposed to mobile-friendly apps).

Phosh [apparently looks for an entry in the .desktop file](https://puri.sm/posts/specify-form-factors-in-your-librem-5-apps/) to determine this. It's apparently also used by other Purism devices, but I guess it's most relevant to the Librem Phone. Other applications such as Resources [also set this key](https://github.com/nokyan/resources/blob/main/data/net.nokyan.Resources.desktop.in.in).